### PR TITLE
Fix spelling mistakes in index.html

### DIFF
--- a/patternlabsite/index.html
+++ b/patternlabsite/index.html
@@ -81,7 +81,7 @@
         <ul class="g g-4up">
           <li class="gi">
             <h3>Static site generator</h3> 
-            <p>At its core, Pattern Lab is a custom static site generator that constructs an interface by stiching atoms, molecules, and organisms together to form templates and pages.</p>
+            <p>At its core, Pattern Lab is a custom static site generator that constructs an interface by stitching atoms, molecules, and organisms together to form templates and pages.</p>
           </li>
           <li class="gi">
             <h3>component library</h3>
@@ -118,7 +118,7 @@
         <ul class="g g-3up">
           <li class="gi">
             <h3>A UI framework</h3>
-            <p>Pattern Lab isn't <a href="http://getbootstrap.com/">Bootstrap</a>. It's not <a href="http://foundation.zurb.com/">Foundation</a>. It's not flat. It's not skeumorphic. We've got nothing against UI frameworks, but that's not what Pattern Lab does. How it looks and how it's coded is entirely up to you.</p>
+            <p>Pattern Lab isn't <a href="http://getbootstrap.com/">Bootstrap</a>. It's not <a href="http://foundation.zurb.com/">Foundation</a>. It's not flat. It's not skeuomorphic. We've got nothing against UI frameworks, but that's not what Pattern Lab does. How it looks and how it's coded is entirely up to you.</p>
            </li>
           <li class="gi">
             <h3>Language-dependent</h3>


### PR DESCRIPTION
Simply fixed a few typos that I noticed on the home page.
