### PR TITLE
Adding four OOCSS frameworks

### DIFF
--- a/patternlabsite/resources.html
+++ b/patternlabsite/resources.html
@@ -37,6 +37,10 @@ title: Resources about Pattern Lab, Atomic Design, Pattern Libraries and Front-e
 		<div class="gi" id="frameworks">
 			<h3>Frameworks</h3>
 			<ul class="list">
+				<li><a href="https://github.com/csswizardry/inuit.css/">Inuit</a></li>
+				<li><a href="http://www.maxmert.com/">Maxmertkit</a></li>
+				<li><a href="http://www.cascade-framework.com/">Cascade Framework</a></li>
+				<li><a href="http://www.apppie.org/">Applepie</a></li>
 				<li><a href="http://getbootstrap.com/">Twitter Bootstrap</a></li>
 				<li><a href="http://foundation.zurb.com/">Foundation Zurb</a></li>
 				<li><a href="http://baselinecss.com/typography.html">Baseline</a></li>


### PR DESCRIPTION
I added four OOCSS frameworks to "frameworks" section.

I added them at the top of the "frameworks" because IMO they're much better examples of atomic design than the frameworks currently listed (which are far more restrictive and monolithic).

I sorted them by number of Github stars (descendingly).

More info about each framework is provided below.
## Inuit
- 3636 stars
- 543 forks
- written in SCSS
- Created by Harry Roberts of http://csswizardry.com/ fame
- Fully implements both OOCSS and BEM
- Focused on structural CSS
- One of the key projects driving the BEM-movement
## Maxmertkit
- 387 stars
- 67 forks
- written in SCSS
- Created by Moscovian developer Vetrenko Maxim
- Uses namespaced modifiers, with different namespaces for widgets, themes, size, component state and animation state
- Comes with a non-optional default theme
- While its flexible namespaced modifiers may look uglier than alternative strategies, this approach combines the readability of BEM with the flexibility of Cascade Framework
## Cascade Framework
- 128 stars
- 33 forks
- written in CSS, with SCSS version in development
- Created by Belgian developer John Slegers (_me_)
- Uses modifiers without namespaces
- Comes with an optional default theme
- It combines a look-and-feel inspired by Bootstrap 1 with a grid architecture inspired by Nicole Sullivan's OOCSS project and a modifier pattern inspired by Maxmertkit
## Applepie
- 109 stars
- 5 forks
- written in SCSS
- Created by the folks at http://railsware.com/
- Both semantic and non-semantic approach are supported out of the box
- Comes with a non-optional default theme
- It's one of the newest kids on the block, but it's growing in popularity fast
