### PR TITLE
Footer links to atoms, molecules, .. were not pointing to 404

### DIFF
--- a/patternlabsite/_includes/footer.html
+++ b/patternlabsite/_includes/footer.html
@@ -2,31 +2,31 @@
   <footer class="footer" role="contentinfo">
 	<ol class="atomic-design small">
           <li>
-            <a href="about.html">
+            <a href="/about.html#atoms">
               <img src="/assets/icon-atom.svg" alt="Atom" />
             </a>
           </li>
           <li>
-            <a href="about.html">
+            <a href="/about.html#molecules">
               <img src="/assets/icon-molecule.svg" alt="Molecule" />
             </a>
           </li>
           <li>
-            <a href="about.html">
+            <a href="/about.html#organisms">
               <img src="/assets/icon-organism.svg" alt="Organism" />
             </a>
           </li>
           <li>
-            <a href="about.html">
+            <a href="/about.html#templates">
               <img src="/assets/icon-template.svg" alt="Template" />
             </a>
           </li>
           <li>
-            <a href="about.html">
+            <a href="/about.html#pages">
               <img src="/assets/icon-page.svg" alt="Page" />
             </a>
           </li>
-        </ol> 
+        </ol>
 
 	<nav class="footer-nav" role="navigation">
 	    <ul>
@@ -38,7 +38,7 @@
 	      <li class="right"><a href="https://github.com/pattern-lab/patternlab-php" rel="external" target="blank">On Github</a></li>
 	    </ul>
 	  </nav>
-	
+
 	<div class="credits">
 		<p>Created by <a href="http://bradfrostweb.com">Brad Frost</a> (<a href="https://twitter.com/brad_frost" rel="external">@brad_frost</a>), <a href="http://dmolsen.com" rel="external">Dave Olsen</a> (<a href="https://twitter.com/dmolsen" rel="external">@dmolsen</a>), and the <a href="https://github.com/pattern-lab/patternlab-php">Web community</a>. </p>
 		<p>Pattern Lab will always be free and open source.</p>
@@ -57,7 +57,7 @@
 	  ga('send', 'pageview');
 
 	</script>
-	
+
 	<script type="text/javascript">
 	  var _gauges = _gauges || [];
 	  (function() {


### PR DESCRIPTION
Footer links to atoms, molecules, .. were not pointing in the right direction : 404 once on a second level page eg: once in docs/ gave docs/about.html = 404

Added missing anchors to links.
