### PR TITLE
Change credit footer to include patternlab org

### DIFF
--- a/patternlabsite/_includes/footer.html
+++ b/patternlabsite/_includes/footer.html
@@ -40,7 +40,7 @@
 	  </nav>
 	
 	<div class="credits">
-		<p>Created by <a href="http://bradfrostweb.com">Brad Frost</a> (<a href="https://twitter.com/brad_frost" rel="external">@brad_frost</a>), <a href="http://dmolsen.com" rel="external">Dave Olsen</a> (<a href="https://twitter.com/dmolsen" rel="external">@dmolsen</a>), and the <a href="https://github.com/pattern-lab/patternlab-php">Web community</a>. </p>
+		<p>Created by <a href="http://bradfrostweb.com">Brad Frost</a> (<a href="https://twitter.com/brad_frost" rel="external">@brad_frost</a>), <a href="http://dmolsen.com" rel="external">Dave Olsen</a> (<a href="https://twitter.com/dmolsen" rel="external">@dmolsen</a>), and the <a href="https://github.com/pattern-lab">Web community</a>. </p>
 		<p>Pattern Lab will always be free and open source.</p>
 	</div>
   </footer><!--end footer-->


### PR DESCRIPTION
This aligns the footer link with the link to the org in the #created-by block.

