### PR TITLE
Fixed missing <p> tag in the comment area

### DIFF
--- a/patternlabsite/docs/pattern-adding-annotations.md
+++ b/patternlabsite/docs/pattern-adding-annotations.md
@@ -15,7 +15,7 @@ To explain how annotations are structured here is the annotation that's added to
 {
 	"el": ".logo",
  	"title" : "Logo",
- 	"comment": "The logo image is an SVG file, which ensures that the logo displays crisply even on high resolution displays. A PNG fallback is provided for browsers that don't support SVG images.</p><p>Further reading: <a href=\"http://bradfrostweb.com/blog/mobile/hi-res-optimization/\">Optimizing Web Experiences for High Resolution Screens</a></p>"
+ 	"comment": "<p>The logo image is an SVG file, which ensures that the logo displays crisply even on high resolution displays. A PNG fallback is provided for browsers that don't support SVG images.</p><p>Further reading: <a href=\"http://bradfrostweb.com/blog/mobile/hi-res-optimization/\">Optimizing Web Experiences for High Resolution Screens</a></p>"
 }
 ```
 


### PR DESCRIPTION
This may have been the cause of page brokenness in Chrome, seen here: 
![screen shot 2016-02-03 at 6 34 51 pm](https://cloud.githubusercontent.com/assets/558258/12804266/76d24b7c-caa6-11e5-9822-7dfa84000271.png)


However I was not able to build the site so I could not preview on my local machine and see if it fixed the problem. I tried following instructions at http://jekyllrb.com/docs/troubleshooting/#installation-problems but I still kept getting these issues: 
![image](https://cloud.githubusercontent.com/assets/558258/12804261/5fa3ed48-caa6-11e5-906b-924d677ad289.png) If there is someone who can assist me on this, it would be fantastic so I can resume debugging this page!
