### PR TITLE
fixing links to the old .info domain;

### DIFF
--- a/_site/docs/requirements.html
+++ b/_site/docs/requirements.html
@@ -10,7 +10,7 @@
 <body class="docs">
     <div class="container">
 	<header class="header" role="banner">
-	
+
 	  <h4 class="logo-header"><a href="/"><span class="atom"></span> Pattern Lab</a></h4>
 
 	  <nav class="nav" role="navigation">
@@ -35,7 +35,7 @@
 
 <p>It&#39;s expected that you&#39;ll use the PHP version of Pattern Lab locally on your computer to develop your atoms, molecules, organisms, templates and pages. To use the basic features of Pattern Lab, you must have <strong>PHP 5.3+</strong> installed. If you&#39;re using Mac OS X you shouldn&#39;t have to install anything and Pattern Lab should work &quot;out of the box.&quot; If you&#39;re on Windows you can <a href="http://windows.php.net/download/#php-5.5">download PHP from PHP.net</a>.</p>
 
-<p>You should <em>not</em> need to set-up Apache or another web server to use Pattern Lab unless you want to use the <a href="http://pattern-lab.info/docs/advanced-page-follow.html">Page Follow feature</a> for multi-device testing.</p>
+<p>You should <em>not</em> need to set-up Apache or another web server to use Pattern Lab unless you want to use the <a href="http://patternlab.io/docs/advanced-page-follow.html">Page Follow feature</a> for multi-device testing.</p>
 
 <p><small><strong>Note:</strong> While the site will work in Safari 6+ the back button is broken in the &quot;Apache-less&quot; version of Pattern Lab.</small></p>
 
@@ -183,6 +183,3 @@
 	</script>
 </body>
 </html>
-
-
-

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -10,7 +10,7 @@ The requirements for the PHP version of Pattern Lab vary depending on what featu
 
 It's expected that you'll use the PHP version of Pattern Lab locally on your computer to develop your atoms, molecules, organisms, templates and pages. To use the basic features of Pattern Lab, you must have **PHP 5.3+** installed. If you're using Mac OS X you shouldn't have to install anything and Pattern Lab should work "out of the box." If you're on Windows you can [download PHP from PHP.net](http://windows.php.net/download/#php-5.5).
 
-You should _not_ need to set-up Apache or another web server to use Pattern Lab unless you want to use the [Page Follow feature](http://pattern-lab.info/docs/advanced-page-follow.html) for multi-device testing.
+You should _not_ need to set-up Apache or another web server to use Pattern Lab unless you want to use the [Page Follow feature](http://patternlab.io/docs/advanced-page-follow.html) for multi-device testing.
 
 <small>**Note:** While the site will work in Safari 6+ the back button is broken in the "Apache-less" version of Pattern Lab.</small>
 


### PR DESCRIPTION
This commit fixes old references to the pattern-lab.info domain. I noticed that the demo's link to documentation also uses this domain.