### PR TITLE
Correct font family name

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -53,7 +53,7 @@ legend {
 body {
 	background: $white;
 	color: $gray-dark;
-	font: 120%/1.4 "HelveticaNeue", "Helvetica", "Arial", sans-serif;
+	font: 120%/1.4 "Helvetica Neue", "Helvetica", "Arial", sans-serif;
 	padding: 0;
 	-webkit-text-size-adjust: 100%;
 }


### PR DESCRIPTION
'Helvetica Neue'