### PR TITLE
Update docs on PHP Pattern States

### DIFF
--- a/docs/pattern-states.md
+++ b/docs/pattern-states.md
@@ -21,14 +21,17 @@ Any pattern that includes a pattern partial that has a lower pattern state will 
 
 ## Giving Patterns a State
 
-Giving patterns a state is simply a matter of modifying the file name. If we wanted to give our `molecules-media-block` pattern a state of `inprogress` we'd change the file name from:
-
-    source/_patterns/01-molecules/02-blocks/00-media-block.mustache
-
-to:
-
-    source/_patterns/01-molecules/02-blocks/00-media-block@inprogress.mustache
-
+Giving patterns a state is accomplished by setting the `state` frontmatter key on any pattern’s companion `.md` file. Consider this media block pattern:
+    
+    ./source/_patterns/molecules/blocks/media-block.mustache
+    
+We would create or edit a file in the same location, calling it `media-block.md`:
+    
+    ---
+    state: inreview
+    ---
+    The media block consists of...
+    
 ## Adding Customized States
 
 The three default states included with the PHP version of Pattern Lab might not be enough for everyone. To add customized states you should modify your own CSS files. **DO NOT** modify `states.css` in `public/styleguide/css/`. This is because `states.css` will be overwritten in future upgrades.


### PR DESCRIPTION
I've made it so [Pattern States](http://patternlab.io/docs/pattern-states.html) in the PHP version are done just like the Node version with MD docs front matter over in [this PR](https://github.com/pattern-lab/patternlab-php-core/pull/134) which is released in v2.8.3. The old behavior of `button@inprogress.mustache` still works with the new approach taking precedence, so I'm not sure if we want to leave something in the docs or what. I'd say no as now PHP & JS has taken one step towards acting similar (not to mention that renaming files with `@inprogress` sucked.

/cc @bradfrost @bmuenzenmeyer 