### PR TITLE
Starterkits

### DIFF
--- a/_includes/docs-nav-advanced.html
+++ b/_includes/docs-nav-advanced.html
@@ -1,7 +1,7 @@
 <ul class="link-list">
 	<li class="link-list__item{% if page.url == '/docs/advanced-ecosystem-overview.html' %} link-list__item--is-selected{% endif %}"><a class="link-list__link" href="/docs/advanced-ecosystem-overview.html">Overview of the Ecosystem</a></li>
+	<li class="link-list__item{% if page.url == '/docs/advanced-config-options.html' %} link-list__item--is-selected{% endif %}"><a class="link-list__link" href="/docs/advanced-starterkits.html">Starterkits</a></li>
 	<li class="link-list__item{% if page.url == '/docs/advanced-reload-browser.html' %} link-list__item--is-selected{% endif %}"><a class="link-list__link" href="/docs/advanced-reload-browser.html">Auto-reloading the browser</a></li>
-	<li class="link-list__item{% if page.url == '/docs/advanced-config-options.html' %} link-list__item--is-selected{% endif %}"><a class="link-list__link" href="/docs/advanced-config-options.html">Editing the configuration options</a></li>
 	<li class="link-list__item{% if page.url == '/docs/advanced-exporting-patterns.html' %} link-list__item--is-selected{% endif %}"><a class="link-list__link" href="/docs/advanced-exporting-patterns.html">Exporting patterns</a></li>
 	<li class="link-list__item{% if page.url == '/docs/advanced-keyboard-shortcuts.html' %} link-list__item--is-selected{% endif %}"><a class="link-list__link" href="/docs/advanced-keyboard-shortcuts.html">Keyboard shortcuts</a></li>
 	<li class="link-list__item{% if page.url == '/docs/advanced-integration-with-grunt.html' %} link-list__item--is-selected{% endif %}"><a class="link-list__link" href="/docs/advanced-integration-with-grunt.html">Integration with Grunt/Gulp</a></li>

--- a/_includes/docs-nav-start.html
+++ b/_includes/docs-nav-start.html
@@ -5,5 +5,6 @@
 	<li class="link-list__item{% if page.url == '/docs/viewing-patterns.html' %} link-list__item--is-selected{% endif %}"><a class="link-list__link" href="/docs/viewing-patterns.html">Viewing</a></li>
 	<li class="link-list__item{% if page.url == '/docs/editing-source-files.html' %} link-list__item--is-selected{% endif %}"><a class="link-list__link" href="/docs/editing-source-files.html">Editing</a></li>
 	<li class="link-list__item{% if page.url == '/docs/command-line.html' %} link-list__item--is-selected{% endif %}"><a class="link-list__link" href="/docs/command-line.html">Using commands</a></li>
+	<li class="link-list__item{% if page.url == '/docs/advanced-config-options.html' %} link-list__item--is-selected{% endif %}"><a class="link-list__link" href="/docs/advanced-config-options.html">Configuring</a></li>
 	<li class="link-list__item{% if page.url == '/docs/upgrading.html' %} link-list__item--is-selected{% endif %}"><a class="link-list__link" href="/docs/upgrading.html">Upgrading</a></li>
 </ul>

--- a/docs/advanced-ecosystem-overview.md
+++ b/docs/advanced-ecosystem-overview.md
@@ -30,6 +30,8 @@ Have a trusty set of boilerplate code that you start every project with? Perhaps
 
 Importing a starterkit is only a few keystrokes away after installation. Eventually this feature will be built into a post-install phase like it is for Pattern Lab PHP via composer.
 
+[Learn more about Starterkits](/docs/advanced-starterkits.html#node)
+
 ### StyleguideKits
 
 StyleguideKits are the front-end of Pattern Lab. We call this “The Viewer.” StyleguideKits allow agencies and organizations to develop custom, branded Pattern Lab UIs to show off their patterns.

--- a/docs/advanced-ecosystem-overview.md
+++ b/docs/advanced-ecosystem-overview.md
@@ -26,7 +26,7 @@ Core is the guts of Pattern Lab and enables all of the other features. Because C
 
 Have a trusty set of boilerplate code that you start every project with? Perhaps a common set of basic patterns, Sass mix-ins, and JavaScript libraries that are your go-to tools? A StarterKit is perfect for bundling these assets together into a boilerplate that makes sure each project starts off on the right foot.
 
-[Several starterkits](https://github.com/pattern-lab/?utf8=✓&query=starterkit-mustache) already exist to kick your project off, whether you’re looking for a blank start, begin with a demo that showcases Pattern Lab’s features, or start with a popular framework like Bootstrap, Foundation, or Material Design. And you can roll your own, which can be fully version-controlled so your team’s StarterKit can evolve along with your tools.
+[Several starterkits](https://github.com/pattern-lab?utf8=%E2%9C%93&q=starterkit&type=&language=) already exist to kick your project off, whether you’re looking for a blank start, begin with a demo that showcases Pattern Lab’s features, or start with a popular framework like Bootstrap, Foundation, or Material Design. And you can roll your own, which can be fully version-controlled so your team’s StarterKit can evolve along with your tools.
 
 Importing a starterkit is only a few keystrokes away after installation. Eventually this feature will be built into a post-install phase like it is for Pattern Lab PHP via composer.
 

--- a/docs/advanced-starterkits.md
+++ b/docs/advanced-starterkits.md
@@ -14,7 +14,7 @@ languages:
 
 {% capture m %}
 
-Starterkits are a potent way create or augment a Pattern Lab instance with a baseline set of patterns and assets. They are an important part of the [Pattern Lab Ecosystem](/docs/advanced-ecosystem-overview.html) An agency or team could use it for each new client or project.
+Starterkits are a potent way create or augment a Pattern Lab instance with a baseline set of patterns and assets. They are an important part of the [Pattern Lab Ecosystem](/docs/advanced-ecosystem-overview.html) An agency or team could use it for each new client or project. [Several starterkits](https://github.com/pattern-lab?utf8=%E2%9C%93&q=starterkit&type=&language=) already exist to kick your project off, whether you’re looking for a blank start, begin with a demo that showcases Pattern Lab’s features, or start with a popular framework like Bootstrap, Foundation, or Material Design.
 
 ## Structure
 

--- a/docs/advanced-starterkits.md
+++ b/docs/advanced-starterkits.md
@@ -14,7 +14,7 @@ languages:
 
 {% capture m %}
 
-Starterkits are a potent way create or augment a Pattern Lab instance with a baseline set of patterns and assets. An agency or team could use it for each new client or project.
+Starterkits are a potent way create or augment a Pattern Lab instance with a baseline set of patterns and assets. They are an important part of the [Pattern Lab Ecosystem](/docs/advanced-ecosystem-overview.html) An agency or team could use it for each new client or project.
 
 ## Structure
 

--- a/docs/advanced-starterkits.md
+++ b/docs/advanced-starterkits.md
@@ -1,0 +1,100 @@
+---
+layout: docs
+title: Starterkits | Pattern Lab
+heading: Starterkits
+languages:
+- language: node
+- language: php
+---
+
+<!--- start node -->
+
+<div class="tabs__panel" id="node">
+<h2 class="language-title">node</h2>
+
+{% capture m %}
+
+Starterkits are a potent way create or augment a Pattern Lab instance with a baseline set of patterns and assets. An agency or team could use it for each new client or project.
+
+## Structure
+
+A Starterkit's structure mirrors that of the default file structure of Pattern Lab. Usually this is found under the `dist/` directory:
+
+```
+_annotations/
+_data/
+_meta/
+_patterns/
+css/
+fonts/
+images/
+js/
+favicon.ico
+```
+
+Teams constructing their own Starterkits should stick to this structure if they wish to publish it externally, else may alter the structure to their [configured `paths`](/docs/advanced-config-options.html#node).
+
+## Installing Starterkits
+
+Open your terminal and navigate to the root of your project. Type:
+
+```
+npm install [starterkit-name]
+gulp patternlab:loadstarterkit --kit=[starterkit-name]
+```
+
+where [starterkit-name] is the name of the Starterkit.
+
+so... a complete example:
+
+```
+npm install starterkit-mustache-demo
+gulp patternlab:loadstarterkit --kit=starterkit-mustache-demo
+```
+
+The [Pattern Lab Node CLI](https://github.com/pattern-lab/patternlab-node-cli) will also support installation of Starterkits should you not be using gulp.
+
+## PSA
+
+**LOADING A STARTERKIT WILL OVERWRITE ANY MATCHES INSIDE `./source`** Users can pass another flag `--clean=true` to attempt to delete the contents of `./source` prior to load.
+
+* Sometimes users will run into file permissions issues. It's recommended to run all command prompts as administrator if you can.
+
+`patternlab-config.json` also defines a `starterkitSubDir` key (with a default value of `dist`) which can be used to target a directory inside the starterkit module if need be.
+
+{% endcapture %}
+{{ m | markdownify }}
+
+</div>
+
+<!--- end node -->
+
+<!--- start php -->
+
+<div class="tabs__panel" id="php">
+<h2 class="language-title">php</h2>
+
+{% capture m %}
+
+StarterKits can be installed via the following commands:
+
+```
+php core/console --starterkit --install [starterkit-name]
+```
+
+where [starterkit-name] is the name of the Starterkit.
+
+so... a complete example:
+
+```
+php core/console --starterkit --install pattern-lab/starterkit-mustache-demo
+```
+
+It is recommended that you do not install this StarterKit as a dependency for your Pattern Lab project via Composer.
+
+{% endcapture %}
+{{ m | markdownify }}
+
+</div>
+
+<!--- end php -->


### PR DESCRIPTION
* Closes #77 
* Closes #67
* Adds starterkit installation
* Also moves configuration to a more prominent location

Doing this will help replace all the startkit installation instructions ([example](https://github.com/pattern-lab/starterkit-mustache-base#install)) with a single-place.