### PR TITLE
Fix possible accessibility issue in V3.0 alert

### DIFF
--- a/_includes/alert.html
+++ b/_includes/alert.html
@@ -1,3 +1,3 @@
 <a href="https://github.com/pattern-lab/patternlab-node/" class="c-alert">
-    The beta of Pattern Lab Node 3.0 is here! Help us kick the tires and make it better.
+    The beta of Pattern Lab Node 3.0 is here! Click here to help us kick the tires and make it better.
 </a>


### PR DESCRIPTION
On the Pattern Lab website I saw the alert at the top but did not know that it was a clickable link until I accidentally clicked on it.

I added a simple "Click here to" to it's contents.

Another possible workaround would be to apply `text-decoration: underline;` even when the link isn't being hovered, but in my opinion that doesn't look as good.