### PR TITLE
Fix command in docs/advanced-auto-regenerate.html

### DIFF
--- a/docs/advanced-auto-regenerate.md
+++ b/docs/advanced-auto-regenerate.md
@@ -21,7 +21,7 @@ Pattern Lab has the ability to watch for changes to patterns and frontend assets
 Open your terminal and navigate to the root of your project. Type:
 
 ```
-gulp patternlab:watch
+gulp patternlab:build --watch
 ```
 
 > If using grunt, substitute `grunt` for `gulp` above.


### PR DESCRIPTION
This resolves #107.

> I'm using the gulp edition of patternlab.
> I tried to use gulp patternlab:watch as per the documentation which didn't work.
> 
> What does work is gulp patternlab:build --watch.
> 
> So if you could update the docs to reflect this or add back in the watch task on gulp version it might save some other poor soul some time.

Well, I fixed it!