### PR TITLE
Add page about PatternEngines

### DIFF
--- a/_includes/docs-nav-advanced.html
+++ b/_includes/docs-nav-advanced.html
@@ -1,6 +1,7 @@
 <ul class="link-list">
 	<li class="link-list__item{% if page.url == '/docs/advanced-ecosystem-overview.html' %} link-list__item--is-selected{% endif %}"><a class="link-list__link" href="/docs/advanced-ecosystem-overview.html">Overview of the Ecosystem</a></li>
 	<li class="link-list__item{% if page.url == '/docs/advanced-starterkits.html' %} link-list__item--is-selected{% endif %}"><a class="link-list__link" href="/docs/advanced-starterkits.html">Starterkits</a></li>
+	<li class="link-list__item{% if page.url == '/docs/advanced-pattern-engines.html' %} link-list__item--is-selected{% endif %}"><a class="link-list__link" href="/docs/advanced-template-language-and-pattern-engines.html">Template language and PatternEngines</a></li>
 	<li class="link-list__item{% if page.url == '/docs/advanced-reload-browser.html' %} link-list__item--is-selected{% endif %}"><a class="link-list__link" href="/docs/advanced-reload-browser.html">Auto-reloading the browser</a></li>
 	<li class="link-list__item{% if page.url == '/docs/advanced-exporting-patterns.html' %} link-list__item--is-selected{% endif %}"><a class="link-list__link" href="/docs/advanced-exporting-patterns.html">Exporting patterns</a></li>
 	<li class="link-list__item{% if page.url == '/docs/advanced-keyboard-shortcuts.html' %} link-list__item--is-selected{% endif %}"><a class="link-list__link" href="/docs/advanced-keyboard-shortcuts.html">Keyboard shortcuts</a></li>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -25,7 +25,8 @@
 <script src="../js/prism.js"></script>
 <script type="text/javascript" src="../js/nav.js"></script>
 <script type="text/javascript" src="../js/init.js"></script>
-<script type="text/javascript" src="../js/pattern-engines.js"></script>
+
+{% if page.patternEnginesScript %}<script type="text/javascript" src="../js/pattern-engines.js"></script>{% endif %}
 
 <script>
 	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -25,6 +25,7 @@
 <script src="../js/prism.js"></script>
 <script type="text/javascript" src="../js/nav.js"></script>
 <script type="text/javascript" src="../js/init.js"></script>
+<script type="text/javascript" src="../js/pattern-engines.js"></script>
 
 <script>
 	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/docs/advanced-template-language-and-pattern-engines.md
+++ b/docs/advanced-template-language-and-pattern-engines.md
@@ -6,6 +6,8 @@ heading: Template Language and PatternEngines
 
 By default Pattern Lab uses the Mustache template language, extended with [pattern parameters](/docs/pattern-parameters.html). PatternEngines let you add support for a template language of your personal choice. Each PatternEngine has it's own set of features and caveats.
 
+Right now the most mature PatternEngines are Handlebars, Mustache and Twig.
+
 ## Official PatternEngines for Node
 <ul id="pattern-engine-list">
   <!-- This list is automatically replaced by a script -->

--- a/docs/advanced-template-language-and-pattern-engines.md
+++ b/docs/advanced-template-language-and-pattern-engines.md
@@ -2,6 +2,7 @@
 layout: docs
 title: Template Language and PatternEngines | Pattern Lab
 heading: Template Language and PatternEngines
+patternEnginesScript: true
 ---
 
 By default Pattern Lab uses the Mustache template language, extended with [pattern parameters](/docs/pattern-parameters.html). PatternEngines let you add support for a template language of your personal choice. Each PatternEngine has it's own set of features and caveats.

--- a/docs/advanced-template-language-and-pattern-engines.md
+++ b/docs/advanced-template-language-and-pattern-engines.md
@@ -1,0 +1,20 @@
+---
+layout: docs
+title: Template Language and PatternEngines | Pattern Lab
+heading: Template Language and PatternEngines
+---
+
+By default Pattern Lab uses the Mustache template language, extended with [pattern parameters](/docs/pattern-parameters.html). PatternEngines let you add support for a template language of your personal choice. Each PatternEngine has it's own set of features and caveats.
+
+## Official PatternEngines for Node
+<ul id="pattern-engine-list">
+  <!-- This list is automatically replaced by a script -->
+  <li>See the [Pattern Lab repository on GitHub](https://github.com/pattern-lab/patternlab-node/tree/master/packages) or [search on npmjs.com](https://www.npmjs.com/search?q=keywords%3A%27Pattern%20Lab%27%20engine)</li>
+</ul>
+
+## Install and Configure a PatternEngine
+
+1. Install a new PatternEngine that you wish to use. For example, to install the Handlebars engine, run `npm install --save @pattern-lab/engine-handlebars`.
+2. (Optional) Change the `"patternExtension"` property of your config. This sets the panel name and language for the code tab on the styleguide.
+
+You'll need to restart Pattern Lab for changes to take effect. Some PatternEngines may provide further configuration.

--- a/docs/advanced-template-language-and-pattern-engines.md
+++ b/docs/advanced-template-language-and-pattern-engines.md
@@ -11,7 +11,7 @@ Right now the most mature PatternEngines are Handlebars, Mustache and Twig.
 ## Official PatternEngines for Node
 <ul id="pattern-engine-list">
   <!-- This list is automatically replaced by a script -->
-  <li>See the [Pattern Lab repository on GitHub](https://github.com/pattern-lab/patternlab-node/tree/master/packages) or [search on npmjs.com](https://www.npmjs.com/search?q=keywords%3A%27Pattern%20Lab%27%20engine)</li>
+  <li>See the <a href="https://github.com/pattern-lab/patternlab-node/tree/master/packages">Pattern Lab repository on GitHub</a> or <a href="https://www.npmjs.com/search?q=keywords%3A%27Pattern%20Lab%27%20engine">search on npmjs.com</a></li>
 </ul>
 
 ## Install and Configure a PatternEngine

--- a/docs/pattern-hiding.md
+++ b/docs/pattern-hiding.md
@@ -13,3 +13,5 @@ To "hide" the pattern we add the underscore and re-generate our site:
     molecules/media/_map.mustache
 
 A hidden pattern can still be included in other patterns.
+
+Not all PatternEngines support hiding patterns.

--- a/docs/pattern-organization.md
+++ b/docs/pattern-organization.md
@@ -4,7 +4,7 @@ title: Overview of Patterns | Pattern Lab
 heading: Overview of Patterns
 ---
 
-Patterns can be found in `./source/_patterns/`. Patterns must be written in the template languages supported by Pattern Lab's PatternEngines. For PHP the supported PatternEngines are Mustache and Twig. For Node the supported PatternEngines are Mustache and Handlebars.
+Patterns can be found in `./source/_patterns/`. Patterns must be written in the template languages supported by Pattern Lab's PatternEngines. For PHP the supported PatternEngines are Mustache and Twig. For Node there are [several more PatternEngines to choose from](/docs/advanced-template-language-and-pattern-engines.html).
 
 ## How Patterns Are Organized
 

--- a/docs/pattern-stylemodifier.md
+++ b/docs/pattern-stylemodifier.md
@@ -4,6 +4,8 @@ title: Using styleModifiers | Pattern Lab
 heading: Using styleModifiers
 ---
 
+**Important:** styleModifiers are only supported by the PHP and Node Mustache PatternEngines. Other template languages provide better solutions to this problem.
+
 styleModifiers provide a way to extend the shorthand include syntax to quickly pass one or more class names to the included pattern.
 
 ## Syntax

--- a/js/pattern-engines.js
+++ b/js/pattern-engines.js
@@ -1,34 +1,68 @@
 'use strict';
 
 // We use the new fetch API and promises. The fallback is to link to a list in the monorepo.
-if (window.fetch !== undefined && typeof Promise !== "undefined") {
+if (window.fetch !== undefined && typeof Promise !== "undefined" && window.localStorage !== undefined) {
+  var localStorageSetItem = function (key, value) {
+    window.localStorage.setItem(key, value);
+  }
+
+  try {
+    // Safari will throw an error in Private Browsing mode if we try to save to LocalStorage
+    window.localStorage.setItem('test', true);
+    window.localStorage.removeItem('test');
+  } catch (e) {
+    localStorageSetItem = function () {};
+  }
+
   (function () {
     var repoPackagesUrl = 'https://api.github.com/repos/pattern-lab/patternlab-node/contents/packages?ref=master';
     var $list = $('#pattern-engine-list');
 
     function getPatternEngineVersion(packagePath) {
-      var packageJsonUrl = 'https://api.github.com/repos/pattern-lab/patternlab-node/contents/<packagePath>/package.json?ref=master'
+      var packageJsonUrl = 'https://api.github.com/repos/pattern-lab/patternlab-node/contents/<packagePath>/package.json?ref=master';
+      var cachedVersion = window.localStorage.getItem(packagePath + '::version');
 
+      if (cachedVersion !== null) {
+        return Promise.resolve(cachedVersion);
+      }
+
+      // Fetch the version if it's not cached
       return window.fetch(packageJsonUrl.replace('<packagePath>', packagePath), { mode: 'cors' })
         .then(function (response) {
           return response.json();
         }).then(function (responseJson) {
-          return JSON.parse(atob(responseJson.content)).version;
+          var version = JSON.parse(atob(responseJson.content)).version;
+
+          // Cache the version
+          localStorageSetItem(packagePath + '::version', version);
+          return version;
         });
     }
 
     $list.html('<li>Loading...</li>');
 
-    // Use the GitHub API to get a list of all the packages in the monorepo
-    window.fetch(repoPackagesUrl, { mode: 'cors' }).then(function (response) {
-      return response.json();
-    }).then(function (responseJson) {
-      $list.html('');
-//function(a, b) { return a.path === b.path ? 0 : a.path > b.path ? 1 : -1 }
-      responseJson.sort().forEach(function (repoPackage) {
-        // Show a list of all the packages starting with `engine-`
-        if (repoPackage.path.indexOf('packages/engine-') === 0) {
+    var cachedPackageList = JSON.parse(window.localStorage.getItem('packages'));
+    var packageListPromise;
 
+    if (cachedPackageList !== null) {
+      packageListPromise = Promise.resolve(cachedPackageList);
+    } else {
+      packageListPromise = window.fetch(repoPackagesUrl, { mode: 'cors' })
+        .then(function (response) {
+          return response.json();
+        }).then(function (packageList) {
+          localStorageSetItem('packages', JSON.stringify(packageList));
+          return packageList;
+        });
+    }
+
+    // Use the GitHub API to get a list of all the packages in the monorepo
+    packageListPromise.then(function (packageList) {
+      $list.html('');
+      packageList.sort().forEach(function (repoPackage) {
+
+        // All the PatternEngine packages start with `engine-`
+        if (repoPackage.path.indexOf('packages/engine-') === 0) {
           var engineName = repoPackage.path.replace('packages/engine-', '');
           $list.append($(
             '<li>'

--- a/js/pattern-engines.js
+++ b/js/pattern-engines.js
@@ -1,83 +1,122 @@
 'use strict';
 
 // We use the new fetch API and promises. The fallback is to link to a list in the monorepo.
-if (window.fetch !== undefined && typeof Promise !== "undefined" && window.localStorage !== undefined) {
-  var localStorageSetItem = function (key, value) {
-    window.localStorage.setItem(key, value);
-  }
-
-  try {
-    // Safari will throw an error in Private Browsing mode if we try to save to LocalStorage
-    window.localStorage.setItem('test', true);
-    window.localStorage.removeItem('test');
-  } catch (e) {
-    localStorageSetItem = function () {};
-  }
-
+if (window.fetch !== undefined && typeof Promise !== 'undefined' && window.localStorage !== undefined) {
   (function () {
     var repoPackagesUrl = 'https://api.github.com/repos/pattern-lab/patternlab-node/contents/packages?ref=master';
-    var $list = $('#pattern-engine-list');
+    var packageJsonUrl = 'https://api.github.com/repos/pattern-lab/patternlab-node/contents/packages/engine-<patternEngine>/package.json?ref=master';
 
-    function getPatternEngineVersion(packagePath) {
-      var packageJsonUrl = 'https://api.github.com/repos/pattern-lab/patternlab-node/contents/<packagePath>/package.json?ref=master';
-      var cachedVersion = window.localStorage.getItem(packagePath + '::version');
+    var storeItem = (function () {
+      try {
+        window.localStorage.setItem('safari-private-browsing-test', true);
+        window.localStorage.removeItem('safari-private-browsing-test');
 
-      if (cachedVersion !== null) {
-        return Promise.resolve(cachedVersion);
+        return function (key, value) {
+          window.localStorage.setItem(key, value);
+        }
+      } catch (e) {
+        return function () {};
+      }
+    })();
+
+    /**
+     * Fetch and cache stuff from the GitHub API, or fetch from the cache available. The cache is
+     * only valid for the current day (i.e. it will be invalidated at midnight).
+     *
+     * We need the cache because there is a rate limit on the GitHub API.
+     *
+     * We need proper error handling because we are likely to hit the rate limit in Safari
+     * Private Browsing mode (saving to LocalStorage doesn't work in Private Browsing).
+     *
+     * @param {string}   key Key to use when saving to LocalStorage
+     * @param {string}   url URL (to the GitHub API)
+     * @param {function} fn  Function that processes the response from the API
+     *
+     * @returns a promise
+     */
+    function fetchAndCache(key, url, fn) {
+      // Wait until the next day before looking for updates. This means that you will get updated
+      // info "tomorrow", whenever "tomorrow" is for you.
+      var date = window.localStorage.getItem(key + '_date');
+      var currentDate = new Date().toJSON().substr(0, 10);
+      var cachedValue = window.localStorage.getItem(key);
+
+      if (cachedValue !== null && date === currentDate) {
+        return Promise.resolve(JSON.parse(cachedValue));
       }
 
+      return window.fetch(url, { mode: 'cors' })
+        .then(function (response) {
+          if (response.status === 200) {
+            return response.json()
+              .then(function (jsonResponse) {
+                var value = fn(jsonResponse);
+
+                storeItem(key, JSON.stringify(value));
+                storeItem(key + '_date', currentDate);
+
+                return value;
+              });
+          }
+
+          // If API call fails we hope that we still have something cached...
+          return JSON.parse(cachedValue);
+        });
+    }
+
+    function getPatternEngines() {
+      return fetchAndCache(
+        'patternEngines',
+        repoPackagesUrl,
+        function (data) {
+          return data
+            .sort()
+            .filter(function (pkg) {
+              return pkg.name.indexOf('engine-') === 0;
+            })
+            .map(function (pkg) {
+              return pkg.name.replace('engine-', '');
+            });
+        }
+      );
+    }
+
+    function getPatternEngineVersion(patternEngine) {
       // Fetch the version if it's not cached
-      return window.fetch(packageJsonUrl.replace('<packagePath>', packagePath), { mode: 'cors' })
-        .then(function (response) {
-          return response.json();
-        }).then(function (responseJson) {
-          var version = JSON.parse(atob(responseJson.content)).version;
-
-          // Cache the version
-          localStorageSetItem(packagePath + '::version', version);
-          return version;
-        });
+      return fetchAndCache(
+        patternEngine + '::version',
+        packageJsonUrl.replace('<patternEngine>', patternEngine),
+        function (data) {
+          return JSON.parse(atob(data.content)).version;
+        }
+      );
     }
 
-    $list.html('<li>Loading...</li>');
-
-    var cachedPackageList = JSON.parse(window.localStorage.getItem('packages'));
-    var packageListPromise;
-
-    if (cachedPackageList !== null) {
-      packageListPromise = Promise.resolve(cachedPackageList);
-    } else {
-      packageListPromise = window.fetch(repoPackagesUrl, { mode: 'cors' })
-        .then(function (response) {
-          return response.json();
-        }).then(function (packageList) {
-          localStorageSetItem('packages', JSON.stringify(packageList));
-          return packageList;
-        });
-    }
 
     // Use the GitHub API to get a list of all the packages in the monorepo
-    packageListPromise.then(function (packageList) {
+    getPatternEngines().then(function (patternEngines) {
+      if (patternEngines === null || patternEngines.length === 0) {
+        return;
+      }
+
+      var $list = $('#pattern-engine-list');
+
       $list.html('');
-      packageList.sort().forEach(function (repoPackage) {
 
-        // All the PatternEngine packages start with `engine-`
-        if (repoPackage.path.indexOf('packages/engine-') === 0) {
-          var engineName = repoPackage.path.replace('packages/engine-', '');
-          $list.append($(
-            '<li>'
-            + '<a href="https://www.npmjs.com/package/@pattern-lab/engine-' + engineName + '">' + engineName + '</a>'
-            + ' ('
-            + '<code>@pattern-lab/engine-' + engineName + '</code>'
-            + ' <span id="' + engineName + '-version"></span>'
-            + ')'
-            + '</li>'));
+      patternEngines.forEach(function (patternEngine) {
+        $list.append($(
+          '<li>'
+          + '<a href="https://www.npmjs.com/package/@pattern-lab/engine-' + patternEngine + '">' + patternEngine + '</a>'
+          + ' ('
+          + '<code>@pattern-lab/engine-' + patternEngine + '</code>'
+          + ' <span id="' + patternEngine + '-version"></span>'
+          + ')'
+          + '</li>'));
 
-          // Add version info
-          getPatternEngineVersion(repoPackage.path).then(function (version) {
-            $('#' + engineName + '-version').text(version);
-          });
-        }
+        // Add version info
+        getPatternEngineVersion(patternEngine).then(function (version) {
+          $('#' + patternEngine + '-version').text(version);
+        });
       });
     });
   })();

--- a/js/pattern-engines.js
+++ b/js/pattern-engines.js
@@ -1,0 +1,50 @@
+'use strict';
+
+// We use the new fetch API and promises. The fallback is to link to a list in the monorepo.
+if (window.fetch !== undefined && typeof Promise !== "undefined") {
+  (function () {
+    var repoPackagesUrl = 'https://api.github.com/repos/pattern-lab/patternlab-node/contents/packages?ref=master';
+    var $list = $('#pattern-engine-list');
+
+    function getPatternEngineVersion(packagePath) {
+      var packageJsonUrl = 'https://api.github.com/repos/pattern-lab/patternlab-node/contents/<packagePath>/package.json?ref=master'
+
+      return window.fetch(packageJsonUrl.replace('<packagePath>', packagePath), { mode: 'cors' })
+        .then(function (response) {
+          return response.json();
+        }).then(function (responseJson) {
+          return JSON.parse(atob(responseJson.content)).version;
+        });
+    }
+
+    $list.html('<li>Loading...</li>');
+
+    // Use the GitHub API to get a list of all the packages in the monorepo
+    window.fetch(repoPackagesUrl, { mode: 'cors' }).then(function (response) {
+      return response.json();
+    }).then(function (responseJson) {
+      $list.html('');
+//function(a, b) { return a.path === b.path ? 0 : a.path > b.path ? 1 : -1 }
+      responseJson.sort().forEach(function (repoPackage) {
+        // Show a list of all the packages starting with `engine-`
+        if (repoPackage.path.indexOf('packages/engine-') === 0) {
+
+          var engineName = repoPackage.path.replace('packages/engine-', '');
+          $list.append($(
+            '<li>'
+            + '<a href="https://www.npmjs.com/package/@pattern-lab/engine-' + engineName + '">' + engineName + '</a>'
+            + ' ('
+            + '<code>@pattern-lab/engine-' + engineName + '</code>'
+            + ' <span id="' + engineName + '-version"></span>'
+            + ')'
+            + '</li>'));
+
+          // Add version info
+          getPatternEngineVersion(repoPackage.path).then(function (version) {
+            $('#' + engineName + '-version').text(version);
+          });
+        }
+      });
+    });
+  })();
+}


### PR DESCRIPTION
Closes https://github.com/pattern-lab/website/issues/101

Added a page about PatternEngines. 

Skimmed through the documentation and updated other pages related to PatternEngines where it seemed appropriate.

The new page includes a list of engines which is populated by a Javascript. The list is taken from the monorepo using the GitHub API. The reasoning behind this is that the list will be kept up-to-date automatically. Drawbacks are that the list requires JS to work (the fallback is a link to the monorepo and a link to a search on npmjs.com), and that the GitHub API has a rate limit. The latter means that if you visit the page too many times the list will fail to load. 

The last issue can easily be solved by caching the API requests using LocalStorage, would that be an acceptable solution? 